### PR TITLE
Upgrade LangChain4j and Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.15.2</quarkus.platform.version>
-        <quarkus-langchain4j.version>0.24.0.CR1</quarkus-langchain4j.version>
-        <langchain4j-embeddings.version>1.0.0-alpha1</langchain4j-embeddings.version>
+        <quarkus.platform.version>3.24.4</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.1.0.CR2</quarkus-langchain4j.version>
+        <langchain4j-embeddings.version>1.1.0-beta7</langchain4j-embeddings.version>
+        <langchain4j.version>1.1.0</langchain4j.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
     </properties>
@@ -41,19 +42,19 @@
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-testing-scorer-junit5</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-testing-scorer-semantic-similarity</artifactId>
-            <version>${quarkus-langchain4j.version}</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-v15</artifactId>
-            <version>1.0.0-alpha1</version>
+            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -63,12 +64,12 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-experimental-sql</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
+            <version>1.1.0-beta7</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-google-ai-gemini</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
+            <version>1.1.0-rc1</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>

--- a/src/main/java/ma/devoxx/langchain4j/dbs/SequenceDbContentRetriever.java
+++ b/src/main/java/ma/devoxx/langchain4j/dbs/SequenceDbContentRetriever.java
@@ -1,7 +1,7 @@
 package ma.devoxx.langchain4j.dbs;
 
 import dev.langchain4j.experimental.rag.content.retriever.sql.SqlDatabaseContentRetriever;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import org.sqlite.SQLiteDataSource;
 
 import javax.sql.DataSource;
@@ -17,12 +17,12 @@ import java.sql.Statement;
 
 public class SequenceDbContentRetriever {
 
-    public SqlDatabaseContentRetriever get(ChatLanguageModel chatLanguageModel) {
+    public SqlDatabaseContentRetriever get(ChatModel chatLanguageModel) {
         DataSource dataSource = createDataSource();
 
         return SqlDatabaseContentRetriever.builder()
                 .dataSource(dataSource)
-                .chatLanguageModel(chatLanguageModel)
+                .chatModel(chatLanguageModel)
                 .build();
     }
 

--- a/src/main/java/ma/devoxx/langchain4j/rag/CustomRetrievalAugmentorV2.java
+++ b/src/main/java/ma/devoxx/langchain4j/rag/CustomRetrievalAugmentorV2.java
@@ -7,7 +7,7 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 //import dev.langchain4j.experimental.rag.content.retriever.sql.SqlDatabaseContentRetriever;
 import dev.langchain4j.experimental.rag.content.retriever.sql.SqlDatabaseContentRetriever;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 //import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
@@ -87,7 +87,7 @@ public class CustomRetrievalAugmentorV2 implements CustomRetrievalAugmentor  {
     }
 
     public RetrievalAugmentor getRetrievalAugmentor() {
-        ChatLanguageModel chatModel = OpenAiChatModel.builder()
+        ChatModel chatModel = OpenAiChatModel.builder()
                 .apiKey(System.getenv("OPENAI_API_KEY"))
                 .build();
 

--- a/src/main/java/ma/devoxx/langchain4j/tools/ToolsForNewAntibodyFinder.java
+++ b/src/main/java/ma/devoxx/langchain4j/tools/ToolsForNewAntibodyFinder.java
@@ -2,7 +2,7 @@ package ma.devoxx.langchain4j.tools;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import jakarta.enterprise.context.ApplicationScoped;
 import ma.devoxx.langchain4j.aiservices.ClaudeAbGenerator;
@@ -39,7 +39,7 @@ public class ToolsForNewAntibodyFinder implements Serializable {
     String designNewAntibodyViaAnthropicClaude(String antigenSequence, String previousAntibodies) {
         Logger.getLogger(ToolsForNewAntibodyFinder.class.getName()).info("designNewAntibodyViaAnthropicClaude() called with antigenSequence='" + antigenSequence + "'");
         try{
-            ChatLanguageModel model = AnthropicChatModel.builder()
+            ChatModel model = AnthropicChatModel.builder()
                     .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                     .modelName("claude-3-haiku-20240307")
                     .logRequests(false)
@@ -47,7 +47,7 @@ public class ToolsForNewAntibodyFinder implements Serializable {
                     .build();
 
             ClaudeAbGenerator claudeAbGenerator = AiServices.builder(ClaudeAbGenerator.class)
-                    .chatLanguageModel(model)
+                    .chatModel(model)
                     .build();
 
             String answer = claudeAbGenerator.generateNewAbSuggestion(antigenSequence, previousAntibodies);

--- a/src/main/java/ma/devoxx/langchain4j/web/rest/SpeechToTextResource.java
+++ b/src/main/java/ma/devoxx/langchain4j/web/rest/SpeechToTextResource.java
@@ -3,7 +3,7 @@ package ma.devoxx.langchain4j.web.rest;
 import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -19,18 +19,18 @@ public class    SpeechToTextResource {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     public String getText(String base64) {
-        ChatLanguageModel model = GoogleAiGeminiChatModel.builder()
+        ChatModel model = GoogleAiGeminiChatModel.builder()
                 .apiKey(API_KEY)
                 .modelName(MODEL_NAME)
                 .logRequestsAndResponses(true)
                 .build();
 
         LOGGER.info("Gemini is converting audio to text...");
-        var response = model.generate(
+        var response = model.chat(
                 SystemMessage.from("repeat the text from the audio message"),
                 new UserMessage(AudioContent.from(base64, "audio/mp3")));
 
-            String message = response.content().text();
+            String message = response.toString();
 
         LOGGER.info("Audio convert. Text = " + message);
 


### PR DESCRIPTION
Upgrade the following dependencies : 
- Quarkus from **3.15.2** to **3.24.4**
- Quarkus LangChain4j from **0.24.0.CR1** to **1.1.0.CR2**
- LangChain4j embeddings from **1.0.0-alpha1** to **1.1.0-beta7**
- LangChain4j from **1.0.0-alpha1** to **1.1.0** (used from LangChain4j-Gemini and LangChain4j-Sql)